### PR TITLE
fix: Redirect oomusou.io to old-oomusou.goodjack.tw

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -76,7 +76,7 @@ Nowdoc 结构是类似于单引号字符串的,可以用在任意的静态数据
 
 ###  回调
 
-* <http://oomusou.io/php/php-closure/>
+* <https://old-oomusou.goodjack.tw/php/closure/>
 
 #### 匿名函数
 


### PR DESCRIPTION
舊的 oomusou.io 文章已經轉移至 old-oomusou.goodjack.tw